### PR TITLE
Update FillableViewer.ts

### DIFF
--- a/src/pdfoundry/viewer/FillableViewer.ts
+++ b/src/pdfoundry/viewer/FillableViewer.ts
@@ -218,7 +218,7 @@ export default class FillableViewer extends BaseViewer {
 
     protected onPageRendered(event) {
         const POLL_INTERVAL = 5;
-        const MAX_POLL_TIME = 250;
+        const MAX_POLL_TIME = 1000;
         const container = $(event.source.div);
 
         new Promise<any>((resolve, reject) => {


### PR DESCRIPTION
I would frequently encounter an error where form-fillable PDFs would fail to render their data. My fix is that I have increased the MAX_POLL_TIME for rendering form-fillable data. That seems to have resolved my issue.